### PR TITLE
Get CommonJS style to work in Node.js

### DIFF
--- a/src/helpers/commonjs.coffee
+++ b/src/helpers/commonjs.coffee
@@ -1,10 +1,12 @@
 module.exports.init = (grunt) ->
   # Wraps some content into CommonJS
   # ---
-  ( content, deps ) ->
+  ( content, deps, pkgName ) ->
     locals = for own key, dep of deps
       do ( key ) =>
         name = key.replace /^\d+|[^\w]+/g, "_"
         """\tvar #{ name } = require(#{ JSON.stringify dep });"""
 
-    "module.exports = function () {\n#{ locals.join "\n" }\n\t#{ content.split( "\n" ).join "\n\t" }\n};"
+    result = if pkgName? then "\n\t// Returning object for nodejs\n\treturn #{ pkgName };" else ""
+
+    "module.exports = function () {\n#{ locals.join "\n" }\n\t#{ content.split( "\n" ).join "\n\t" }#{ result }\n};\n"

--- a/src/tasks/dust.coffee
+++ b/src/tasks/dust.coffee
@@ -77,7 +77,7 @@ module.exports = ( grunt ) ->
 				if options.wrapper is "amd"
 					joined = amdHelper joined, options.wrapperOptions.deps, options.wrapperOptions.packageName
 				else if options.wrapper is "commonjs"
-					joined = commonjsHelper joined, options.wrapperOptions.deps
+					joined = commonjsHelper joined, options.wrapperOptions.deps, options.wrapperOptions.packageName
 
 				grunt.file.write file.dest, joined
 


### PR DESCRIPTION
Grunt Dust supports to module systems, AMD and CommonJS. CommonJS
is the basis of RequireJS. One of the odd things though, is that
it  doens't return an object. So, when using it in Node.js, you
don't get back the Dust template cache.

Added in the ability to pass in `packageName` as an option that
will define what variable to return. More than likely it will be
the value for the dust variable. But, instead of trying to guess
it, I've made it explicit.
