### PR TITLE
Use base name

### DIFF
--- a/src/tasks/dust.coffee
+++ b/src/tasks/dust.coffee
@@ -31,6 +31,7 @@ module.exports = ( grunt ) ->
 		options = @options
 			runtime: yes
 			basePath: no
+			useBaseName: no
 			relative: no
 			wrapper: "amd"
 			wrapperOptions:


### PR DESCRIPTION
Added 'useBaseName' (boolean) option. If 'true' template names will be the same as the basename of the file, sans prepended paths and file extensions. When coupled with globbing pattern '[root_folder]/*_/_' all files matched will use their base names regardless of where the file is located in the directory tree rooted at root_folder. Note: One caveat - filenames must be unique! Otherwise name collisions will occur.
