### PR TITLE
Forcing unix path separator for proper AMD pathing. Windows path separat...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /examples/dst/
+/src/tmp/

--- a/src/helpers/amd.coffee
+++ b/src/helpers/amd.coffee
@@ -12,6 +12,5 @@ module.exports.init = (grunt) ->
 
 		parts.push JSON.stringify( name ) if name?.length ? 0 > 0
 		parts.push "[#{ paths.join "," }]" if paths.length
-		parts.push """function (#{ args.join "," }) {\n\t#{ content.split( "\n" ).join "\n\t" }\n\treturn #{ JSON.stringify returning };\n}"""
-
+		parts.push """function (#{ args.join "," }) {\n\t#{ content.split( "\n" ).join "\n\t" } #{ "\n\treturn " + JSON.stringify returning if !!returning };\n}"""
 		"define(#{ parts.join( "," ) });"

--- a/src/tasks/dust.coffee
+++ b/src/tasks/dust.coffee
@@ -95,15 +95,7 @@ module.exports = ( grunt ) ->
 				joined = output.join( "\n ")
 
 				if options.wrapper is "amd"
-					# what should return AMD wrapper
-					switch tplNames.length
-						when 0
-							returning = undefined
-						when 1
-							returning = _.last tplNames
-						else
-							returning = tplNames
-
+					returning = null
 					joined = amdHelper joined, options.wrapperOptions.deps, options.wrapperOptions.packageName, returning
 				else if options.wrapper is "commonjs"
 					joined = commonjsHelper joined, options.wrapperOptions.deps, options.wrapperOptions.returning


### PR DESCRIPTION
...or was resulting in illegal charater escapes. Fixes vtsvang/grunt-dust#17.
