### PR TITLE
update docs to include wrapper: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Task targets, files and options may be specified according to the grunt [Configu
 Type: `String/boolean`
 Default: "amd"
 
-Wrapper style to use - "amd" or "commonjs" are the only accepted values.
+Wrapper style to use. Accepted values are `'amd'`, `'commonjs'`, and `false`.
 
 #### wrapperOptions
 Type: `Object`


### PR DESCRIPTION
For the wrapper, the docs said there were only two accepted values (`'amd'` and `'commonjs'`) but really `false` is a third value. I had a little trouble figuring this out at first, so I wanted to help the people who come after me by specifying the third option in the README.
