### PR TITLE
Added whitespace option.

### DIFF
--- a/src/tasks/dust.coffee
+++ b/src/tasks/dust.coffee
@@ -36,6 +36,7 @@ module.exports = ( grunt ) ->
 			relative: no
 			wrapper: "amd"
 			optimizers: {}
+			whitespace: no
 			wrapperOptions:
 				packageName: ""
 				returning: "dust"
@@ -45,6 +46,9 @@ module.exports = ( grunt ) ->
 
 		# override optimizers
 		optimizers.replace options.optimizers if options.optimizers?
+
+		# add whitespace parameter
+		dust.config.whitespace = options.whitespace
 
 		if options.amd
 			grunt.log.error """Notice: option "amd" is deprecated and will be removed in next version.""".yellow


### PR DESCRIPTION
The newest version of dust provides a config option to allow configuring removing or not whitespace (old method doesn't work anymore). Added that option.
